### PR TITLE
Refactor models

### DIFF
--- a/sample-output-2.json.txt
+++ b/sample-output-2.json.txt
@@ -1,1 +1,1 @@
-[{"job_assigned":{"job_id":"c0033410-981c-428a-954a-35dec05ef1d2","agent_id":"8ab86c18-3fae-4804-bfd9-c3d6e8f66260"}},{"job_assigned":{"job_id":"f26e890b-df8e-422e-a39c-7762aa0bac36","agent_id":"ed0e23ef-6c2b-430c-9b90-cd4f1ff74c88"}}]
+"key-fn"

--- a/src/queues/core.clj
+++ b/src/queues/core.clj
@@ -171,18 +171,18 @@
 
 (defmethod added-event ::events/new-agent [agents-and-jobs event]
   (->> event
-       (namespaced-kws-content "queues.models.agent")
+       ;;(namespaced-kws-content "queues.models.agent")
        ((fn [content] #(conj % content)))
        (update agents-and-jobs ::aajs/agents)))
 
 (defmethod added-event ::events/new-job [agents-and-jobs event]
   (->> event
-       (namespaced-kws-content "queues.models.job")
+       ;;(namespaced-kws-content "queues.models.job")
        (processed-new-job agents-and-jobs)))
 
 (defmethod added-event ::events/job-request [agents-and-jobs event]
   (->> event
-       (namespaced-kws-content "queues.models.job-request")
+       ;;(namespaced-kws-content "queues.models.job-request")
        (processed-job-req agents-and-jobs)))
 
 ;;FIXME: Make it clear in Readme that the program will assume that a job request
@@ -209,7 +209,8 @@
       (json/read-json-events)
       (dequeue)
       (json/write-json-events)
-      (#(spit "sample-output-2.json.txt" %))))
+      (#(spit "sample-output-2.json.txt" %))
+      ))
 
 ;;TODO: implement run time type checks for variables and clojure spec fdefn for functions
 ;;TODO: implement logging functionality

--- a/src/queues/json.clj
+++ b/src/queues/json.clj
@@ -1,5 +1,7 @@
 (ns queues.json
   (:require [clojure.data.json :as json]
+            [clojure.string :as str]
+            [clojure.pprint :as pp]
             [queues.models.events :as events]
             [queues.models.agent :as agent]
             [queues.models.job :as job]
@@ -18,10 +20,63 @@
     ::agent/id "agent_id"
     org-kw))
 
+(defn js-kw->cj-kw
+  "Receives a json formatted keyword and a namespace
+  and returns an equivalent clojure keyword"
+  [namespace js-kw]
+  (->> js-kw
+       (#(str/replace % #"_" "-"))
+       (keyword namespace)))
+
+(defn namespaced-kw-type
+  [event]
+  (->> event
+       ((comp first keys))
+       (js-kw->cj-kw "queues.models.events")))
+
+(defn namespaced-kws-content
+  [namespace event]
+  (->> event
+       ((comp first vals))
+       (reduce-kv (fn [content k v]
+                    (assoc content (js-kw->cj-kw (str "queues.models." namespace) k) v))
+                  {})))
+
+(defn namespaced-kws-event
+  "Receives a jason formatted event and a namespace and returns
+  that event's content with keywords transformed in namespaced
+  symbols"
+  [namespace event]
+  (let [type (namespaced-kw-type event)
+        content (namespaced-kws-content namespace event)]
+    ;;(hash-map type content)
+    content
+    ))
+
+(defmulti read-json-event (fn [_ event] ((comp first keys) event)))
+
+(defmethod read-json-event "new_agent" [clj-events event]
+  (->> event
+       (namespaced-kws-event "agent")
+       (conj clj-events)))
+
+(defmethod read-json-event "new_job" [clj-events event]
+  (->> event
+       (namespaced-kws-event "job")
+       (conj clj-events)))
+
+(defmethod read-json-event "job_request" [clj-events event]
+  (->> event
+       (namespaced-kws-event "job-request")
+       (conj clj-events)))
+
 (defn read-json-events
-  "Receives json formatted events and returns clojure formatted events"
-  [json-events]
-  (json/read-str :key-fn converted-kws json-events))
+  "Receives a string with json formatted events
+  and returns a vector with clojure formatted events"
+  [str]
+  (->> str
+       (json/read-str)
+       (reduce read-json-event [])))
 
 (defn write-json-events
   "Receives clj formatted events and returns json formatted events"

--- a/src/queues/models/agent.clj
+++ b/src/queues/models/agent.clj
@@ -5,6 +5,6 @@
 (s/def ::id string?)
 (s/def ::name string?)
 (s/def ::primary-skillset (s/coll-of ::job/type :into [] :count 1))
-(s/def ::secondary-skillset (s/coll-of ::job/type :into [] :count 1))
+(s/def ::secondary-skillset (s/coll-of ::job/type :into [] :max-count 1))
 
 (s/def ::agent (s/keys :req [::id ::primary-skillset ::secondary-skillset]))

--- a/src/queues/models/events.clj
+++ b/src/queues/models/events.clj
@@ -4,16 +4,24 @@
             [queues.models.agent :as agent]
             [queues.models.job-request :as jr]))
 
-(s/def ::new-agent ::agent/agent)
-(s/def ::new-job ::job/job)
-(s/def ::job-request ::jr/job-request)
+(s/def ::type keyword?)
 
-(s/def ::new-agent-event (s/keys :req [::new-agent]))
-(s/def ::new-job-event (s/keys :req [::new-job]))
-(s/def ::job-request-event (s/keys :req [::job-request]))
+(defmulti event-type ::type)
 
-(s/def ::events (s/coll-of (s/or :new-agent ::new-agent-event
-                                 :new-job ::new-job-event
-                                 :job-request ::job-request-event)
+(defmethod event-type ::agent/agent [_]
+  (s/keys :req [::type ::agent/id ::agent/name ::agent/primary-skillset ::agent/secondary-skillset]))
+
+(defmethod event-type ::job/job [_]
+  (s/keys :req [::type ::job/id ::job/type ::job/urgent]))
+
+(defmethod event-type ::jr/job-request [_]
+  (s/keys :req [::type ::agent/id]))
+
+(s/def ::event (s/multi-spec event-type ::type))
+
+(defmethod event-type ::job-assigned [_]
+  (s/keys :req [::type ::agent/id ::job/id]))
+
+(s/def ::events (s/coll-of ::event
                            :distinct true
                            :into []))

--- a/test/queues/core_test.clj
+++ b/test/queues/core_test.clj
@@ -15,17 +15,17 @@
                               ::aajs/jobs-waiting         []
                               ::aajs/job-requests-waiting []}]
 
-  (let [new-agent-1 {::events/new-agent {"id"                 "8ab86c18-3fae-4804-bfd9-c3d6e8f66260",
-                                         "name"               "BoJack Horseman",
-                                         "primary_skillset"   ["bills-questions"],
-                                         "secondary_skillset" []}}
-        new-job-1 {::events/new-job {"id"     "f26e890b-df8e-422e-a39c-7762aa0bac36",
-                                     "type"   "rewards-question",
-                                     "urgent" false}}
-        new-job-2 {::events/new-job {"id"     "c0033410-981c-428a-954a-35dec05ef1d2",
-                                     "type"   "bills-questions",
-                                     "urgent" true}}
-        job-request {::events/job-request {"agent_id" "8ab86c18-3fae-4804-bfd9-c3d6e8f66260"}}
+  (let [new-agent-1 {::agent/id                 "8ab86c18-3fae-4804-bfd9-c3d6e8f66260",
+                     ::agent/name               "BoJack Horseman",
+                     ::agent/primary-skillset   ["bills-questions"],
+                     ::agent/secondary-skillset []}
+        new-job-1 {::job/id     "f26e890b-df8e-422e-a39c-7762aa0bac36",
+                   ::job/type   "rewards-question",
+                   ::job/urgent false}
+        new-job-2 {::job/id     "c0033410-981c-428a-954a-35dec05ef1d2",
+                   ::job/type   "bills-questions",
+                   ::job/urgent true}
+        job-request {::jr/agent-id "8ab86c18-3fae-4804-bfd9-c3d6e8f66260"}
         job-assigned {::ja/job-assigned {::job/id   "c0033410-981c-428a-954a-35dec05ef1d2",
                                          ::jr/agent-id "8ab86c18-3fae-4804-bfd9-c3d6e8f66260"}}
         agent #:queues.models.agent{:id                 "8ab86c18-3fae-4804-bfd9-c3d6e8f66260",


### PR DESCRIPTION
Refactor events to be a defmulti spec, making easy to refactor added event based on the event type with events formatted for clojure without the need of the extra {:event-type {content}} map depth. 