### PR TITLE
Get / endpoint

### DIFF
--- a/src/queues/controllers/batch_processor.clj
+++ b/src/queues/controllers/batch_processor.clj
@@ -62,7 +62,7 @@
   (when pretty-print (cli/print-job-queue-to-console! jobs-assigned))
   ;; mandatory options, always executed
   (-> jobs-assigned
-      (json-converter/json-events-str-formatted-from-clj-events)
+      (json-converter/json-events-str-from-clj-events)
       (io/output-job-queue-str-formatted-to-file! output-file)))
 
 (s/fdef outputs-job-assigned-json-formatted-events-to-output-options!

--- a/src/queues/json_converter.clj
+++ b/src/queues/json_converter.clj
@@ -88,6 +88,14 @@
         :args (s/cat :json-events ::specs.json-events/json-events)
         :ret ::specs.events/events)
 
+(defn json-event-from-json-event-str
+  [json-event-str]
+  (che/parse-string json-event-str))
+
+(s/fdef json-event-from-json-event-str
+        :args (s/cat :json-event-str string?)
+        :ret ::specs.json-events/json-event)
+
 (defn- json-events-vec-from-json-events-str
   [json-events-str]
   (if-let [json-events-vec (che/parse-string json-events-str)]

--- a/src/queues/json_converter.clj
+++ b/src/queues/json_converter.clj
@@ -58,7 +58,9 @@
   (let [[js-event-type js-event-payload] (first js-event)
         clj-event-type (ns-kwd-key-from-json-key "events" js-event-type)
         clj-event-payload (clj-event-payload-from-json-type-and-payload js-event-type js-event-payload)]
-    {clj-event-type clj-event-payload}))
+    (->> {clj-event-type clj-event-payload}
+         (s/conform ::specs.events/event)
+         (second))))
 
 (s/fdef clj-event-from-json-event
         :args (s/cat :js-event map?)
@@ -95,6 +97,16 @@
 (s/fdef json-event-from-json-event-str
         :args (s/cat :json-event-str string?)
         :ret ::specs.json-events/json-event)
+
+(defn clj-event-from-json-event-str
+  [json-event-str]
+  (-> json-event-str
+      (json-event-from-json-event-str)
+      (clj-event-from-json-event)))
+
+(s/fdef clj-event-from-json-event-str
+        :args (s/cat :json-event-str string?)
+        :ret ::specs.events/event)
 
 (defn- json-events-vec-from-json-events-str
   [json-events-str]

--- a/src/queues/json_converter.clj
+++ b/src/queues/json_converter.clj
@@ -48,7 +48,7 @@
                      :js-event-payload map?)
         :ret ::specs.events/event)
 
-(defn- clj-event-from-json-event
+(defn clj-event-from-json-event
   [js-event]
   (let [[js-event-type js-event-payload] (first js-event)
         clj-event-type (clj-key-from-json-key js-event-type)
@@ -135,12 +135,13 @@
         :args (s/cat :clj-ns-kwd-key keyword?)
         :ret string?)
 
-(defn json-events-str-formatted-from-clj-events
+(defn json-events-str-from-clj-events
   [clj-events]
   (che/generate-string clj-events {:key-fn json-key-from-clj-ns-kwd-key :pretty true}))
 
-(s/fdef json-events-str-formatted-from-clj-events
-        :args (s/cat :clj-events ::specs.jobs-assigned/jobs-assigned)
+(s/fdef json-events-str-from-clj-events
+        :args (s/cat :clj-events (s/or :jobs-assigned ::specs.jobs-assigned/jobs-assigned
+                                       :event ::specs.events/event))
         :ret string?)
 
 ;; TODO [IMPROVE] Have two specs for events: input-events and output-events

--- a/src/queues/service.clj
+++ b/src/queues/service.clj
@@ -27,11 +27,22 @@
                  resp (ok body headers)]
              (assoc context :response resp)))})
 
+(def job-queues
+  {:name  :job-queues
+   :enter (fn [context]
+            ;;(->> (state/all-agents-indexed-by-id (init/db))
+            ;;     (map #(first (vals %)))
+            ;;     (json-converter/json-events-str-formatted-from-clj-events))
+            (let [body "{\n  \"jobs_done\": [],\n  \"jobs_being_done\": [],\n  \"jobs_queued\": []\n}"
+                  headers (:headers context)
+                  resp (ok body headers)]
+              (assoc context :response resp)))})
+
 (def routes
-  ; Output should give a breakdown of the job queue, consisting of all completed jobs,
-  ; jobs that are being done and jobs queued to be assigned to an agent.
   (route/expand-routes
-    #{["/" :get echo :route-name :queue-state]
+    ; Output should give a breakdown of the job queue, consisting of all completed jobs,
+    ; jobs that are being done and jobs queued to be assigned to an agent.
+    #{["/" :get job-queues :route-name :job-queues]
       ; create a new agent, returns agent :id and status
       ["/agents" :post echo :route-name :agent-create]
       ; returns how many jobs of each type this agent has performed and its status

--- a/src/queues/service.clj
+++ b/src/queues/service.clj
@@ -1,9 +1,10 @@
 (ns queues.service
   (:require [clojure.spec.alpha :as s]
             [io.pedestal.http :as http]
-            [io.pedestal.http.route :as route]
             [io.pedestal.http.body-params :as body-params]
-            [ring.util.response :as ring-resp]))
+            [io.pedestal.http.route :as route]
+            [ring.util.response :as ring-resp]
+            [queues.json-converter :as json-converter]))
 
 (defn response [status body headers]
   {:status status :body body :headers headers})
@@ -17,22 +18,27 @@
 (def ok (partial response 200))
 (def created (partial response 201))
 (def accepted (partial response 202))
+(def bad-request (partial response 400))
 
-(def echo
-  {:name :echo
-   :enter
-         (fn [context]
-           (let [body (:body context)
-                 headers (:headers context)
-                 resp (ok body headers)]
-             (assoc context :response resp)))})
+(def create-agent
+  {:name  :echo
+   :leave (fn [context]
+            (let [json-params (get-in context [:request :json-params])
+                  headers (:headers context)
+                  resp (try
+                         (if-let [clj-event (json-converter/clj-event-from-json-event json-params)]
+                           (-> clj-event
+                               json-converter/json-events-str-from-clj-events
+                               (created headers)))
+                         (catch Exception e
+                           ;; TODO [IMPROVE] catch should return 400 only when app is sure the problem is really with the input
+                           (bad-request (str "caught exception: " (.getMessage e))
+                                        headers)))]
+              (assoc context :response resp)))})
 
 (def job-queues
   {:name  :job-queues
    :enter (fn [context]
-            ;;(->> (state/all-agents-indexed-by-id (init/db))
-            ;;     (map #(first (vals %)))
-            ;;     (json-converter/json-events-str-formatted-from-clj-events))
             (let [body "{\n  \"jobs_done\": [],\n  \"jobs_being_done\": [],\n  \"jobs_queued\": []\n}"
                   headers (:headers context)
                   resp (ok body headers)]
@@ -43,14 +49,15 @@
     ; Output should give a breakdown of the job queue, consisting of all completed jobs,
     ; jobs that are being done and jobs queued to be assigned to an agent.
     #{["/" :get job-queues :route-name :job-queues]
-      ; create a new agent, returns agent :id and status
-      ["/agents" :post echo :route-name :agent-create]
-      ; returns how many jobs of each type this agent has performed and its status
-      ["/agents/:id" :get echo :route-name :agent-status]
-      ; create a new job, returns job :id and status
-      ["/jobs" :post echo :route-name :job-create]
-      ; create a job-request, return the job-id assigned or the job-request with queued status
-      ["/job-requests" :post echo :route-name :job-request-create]}))
+      ; create a new agent, returns the agent
+      ["/agents" :post [(body-params/body-params) create-agent] :route-name :agent-create]
+      ;;; returns how many jobs of each type this agent has performed and its status
+      ;;["/agents/:id" :get echo :route-name :agent-status]
+      ;;; create a new job, returns job :id and status
+      ;;["/jobs" :post echo :route-name :job-create]
+      ;;; create a job-request, return the job-id assigned or the job-request with queued status
+      ;;["/job-requests" :post echo :route-name :job-request-create]
+      }))
 
 (def service {:env          :prod
               ::http/routes routes

--- a/src/queues/specs/json_events.clj
+++ b/src/queues/specs/json_events.clj
@@ -5,20 +5,20 @@
             [queues.specs.job-assigned :as specs.job-assigned]
             [queues.specs.job-request :as specs.job-req]))
 
+(s/def ::json-key keyword?)
 
-
-(s/def ::new-agent (s/map-of string? (s/or :val any?
+(s/def ::new-agent (s/map-of ::json-key (s/or :val any?
                                            :vec (s/coll-of string?))))
-(s/def ::new-job (s/map-of string? any?))
-(s/def ::job-request (s/map-of string? any?))
+(s/def ::new-job (s/map-of ::json-key any?))
+(s/def ::job-request (s/map-of ::json-key any?))
 
-(s/def ::new-agent-map (s/map-of string? ::new-agent))
-(s/def ::new-job-map (s/map-of string? ::new-job))
-(s/def ::job-request-map (s/map-of string? ::job-request))
+(s/def ::new-agent-map (s/map-of ::json-key ::new-agent))
+(s/def ::new-job-map (s/map-of ::json-key ::new-job))
+(s/def ::job-request-map (s/map-of ::json-key ::job-request))
 
 (s/def ::json-event (s/or :new_agent ::new-agent-map
-                     :new_job ::new-job-map
-                     :job_request ::job-request-map))
+                          :new_job ::new-job-map
+                          :job_request ::job-request-map))
 
 (s/def ::json-events (s/coll-of ::json-event
                                 :into []))

--- a/test/queues/fixtures.clj
+++ b/test/queues/fixtures.clj
@@ -3,11 +3,16 @@
             [clojure.spec.gen.alpha :as gen]
             [clojure.spec.test.alpha :as stest]
             [clojure.test :refer :all]
+            [io.pedestal.http :as http]
+            [queues.server :as server]
+            [queues.service :as service]
             [queues.specs.agents :as specs.agents]
             [queues.specs.events :as specs.events]
             [queues.specs.job :as specs.job]
             [queues.specs.job-request :as specs.job-request]
             [queues.specs.queues :as specs.queues]))
+
+(def tempserv (::http/service-fn (http/create-servlet service/service)))
 
 (def runs-for-each-prop-tests 100)
 

--- a/test/queues/json_converter_test.clj
+++ b/test/queues/json_converter_test.clj
@@ -58,6 +58,11 @@
          (clj-events-with-converted-json-event [cases/new-agent-clj-event-p1] cases/job-req-json-event-p1) => [cases/new-agent-clj-event-p1 cases/job-req-clj-event-p1])
   (facts "clj-events-from-json-events"
          (clj-events-from-json-events cases/json-events) => cases/clj-events)
+  (facts "json-event-from-json-event-str"
+         (fact "if provided with a valid event str returns a corresponding json event"
+               (json-event-from-json-event-str cases/agent-p1-str) => cases/new-agent-json-event-p1)
+         (fact "if provided with an invalid event throws an exception"
+               (json-event-from-json-event-str "[/]") => (throws Exception)))
   (facts "json-events-vec-from-json-events-str"
          (json-events-vec-from-json-events-str cases/json-events-str) => cases/json-events)
   (facts "clj-events-from-json-events-str"
@@ -67,6 +72,7 @@
          (json-key-from-clj-ns-kwd-key ::specs.job-assigned/job-id) => "job_id"
          (json-key-from-clj-ns-kwd-key ::specs.job-assigned/agent-id) => "agent_id")
   (facts "json-events-str-formatted-from-clj-events"
-         (json-events-str-formatted-from-clj-events cases/jobs-assigned-clj-events) => cases/jobs-assigned-json-events-str))
+         (json-events-str-formatted-from-clj-events cases/jobs-assigned-clj-events) => cases/jobs-assigned-json-events-str)
+  )
 
 (stest/instrument)

--- a/test/queues/json_converter_test.clj
+++ b/test/queues/json_converter_test.clj
@@ -12,35 +12,25 @@
             [queues.specs.job-request :as specs.job-request]
             [queues.test-cases :as cases]))
 
-(let [ns-kwd-key-from-json-key #'queues.json-converter/ns-kwd-key-from-json-key
-      clj-event-payload-from-namespace-and-json-event-payload #'queues.json-converter/clj-event-payload-from-namespace-and-json-event-payload
-      ns-from-js-event-type #'queues.json-converter/ns-from-js-event-type
+(let [clj-key-from-json-key #'queues.json-converter/clj-key-from-json-key
       clj-event-payload-from-json-type-and-payload #'queues.json-converter/clj-event-payload-from-json-type-and-payload
       clj-event-from-json-event #'queues.json-converter/clj-event-from-json-event
       clj-events-with-converted-json-event #'queues.json-converter/clj-events-with-converted-json-event
       clj-events-from-json-events #'queues.json-converter/clj-events-from-json-events
       json-events-vec-from-json-events-str #'queues.json-converter/json-events-vec-from-json-events-str
       json-key-from-clj-ns-kwd-key #'queues.json-converter/json-key-from-clj-ns-kwd-key]
-  (facts "ns-kwd-key-from-json-key"
-         (ns-kwd-key-from-json-key "agents" :id) => ::specs.agents/id
-         (ns-kwd-key-from-json-key "agents" :name) => ::specs.agents/name
-         (ns-kwd-key-from-json-key "agents" :primary_skillset) => ::specs.agents/primary-skillset
-         (ns-kwd-key-from-json-key "agents" :secondary_skillset) => ::specs.agents/secondary-skillset
-         (ns-kwd-key-from-json-key "job" :id) => ::specs.job/id
-         (ns-kwd-key-from-json-key "job" :type) => ::specs.job/type
-         (ns-kwd-key-from-json-key "job" :urgent) => ::specs.job/urgent
-         (ns-kwd-key-from-json-key "job-request" :agent-id) => ::specs.job-request/agent-id
-         (ns-kwd-key-from-json-key "events" :new_agent) => ::specs.events/new-agent
-         (ns-kwd-key-from-json-key "events" :new_job) => ::specs.events/new-job
-         (ns-kwd-key-from-json-key "events" :job_request) => ::specs.events/job-request)
-  (facts "clj-event-payload-from-namespace-and-json-event-payload"
-         (clj-event-payload-from-namespace-and-json-event-payload "agents" cases/new-agent-json-event-payload-p1) => cases/agent-p1
-         (clj-event-payload-from-namespace-and-json-event-payload "job" cases/new-job-json-payload-1t) => cases/job-1t
-         (clj-event-payload-from-namespace-and-json-event-payload "job-request" cases/job-req-json-event-payload-p1) => cases/job-req-p1)
-  (facts "ns-from-js-event-type"
-         (ns-from-js-event-type cases/new-agent-json-event-type-p1) => "agents"
-         (ns-from-js-event-type cases/new-job-json-type-1t) => "job"
-         (ns-from-js-event-type cases/job-req-json-event-type-p1) => "job-request")
+  (facts "clj-key-from-json-key"
+         (clj-key-from-json-key :new_agent :id) => ::specs.agents/id
+         (clj-key-from-json-key :new_agent :name) => ::specs.agents/name
+         (clj-key-from-json-key :new_agent :primary_skillset) => ::specs.agents/primary-skillset
+         (clj-key-from-json-key :new_agent :secondary_skillset) => ::specs.agents/secondary-skillset
+         (clj-key-from-json-key :new_job :id) => ::specs.job/id
+         (clj-key-from-json-key :new_job :type) => ::specs.job/type
+         (clj-key-from-json-key :new_job :urgent) => ::specs.job/urgent
+         (clj-key-from-json-key :job_request :agent_id) => ::specs.job-request/agent-id
+         (clj-key-from-json-key :new_agent) => ::specs.events/new-agent
+         (clj-key-from-json-key :new_job) => ::specs.events/new-job
+         (clj-key-from-json-key :job_request) => ::specs.events/job-request)
   (facts "clj-event-payload-from-json-type-and-payload"
          (clj-event-payload-from-json-type-and-payload cases/new-agent-json-event-type-p1
                                                        cases/new-agent-json-event-payload-p1) => cases/agent-p1

--- a/test/queues/json_converter_test.clj
+++ b/test/queues/json_converter_test.clj
@@ -68,7 +68,7 @@
          (json-key-from-clj-ns-kwd-key ::specs.job-assigned/job-assigned) => "job_assigned"
          (json-key-from-clj-ns-kwd-key ::specs.job-assigned/job-id) => "job_id"
          (json-key-from-clj-ns-kwd-key ::specs.job-assigned/agent-id) => "agent_id")
-  (facts "json-events-str-formatted-from-clj-events"
-         (json-events-str-formatted-from-clj-events cases/jobs-assigned-clj-events) => cases/jobs-assigned-json-events-str))
+  (facts "json-events-str-from-clj-events"
+         (json-events-str-from-clj-events cases/jobs-assigned-clj-events) => cases/jobs-assigned-json-events-str))
 
 (stest/instrument)

--- a/test/queues/json_converter_test.clj
+++ b/test/queues/json_converter_test.clj
@@ -22,17 +22,17 @@
       json-events-vec-from-json-events-str #'queues.json-converter/json-events-vec-from-json-events-str
       json-key-from-clj-ns-kwd-key #'queues.json-converter/json-key-from-clj-ns-kwd-key]
   (facts "ns-kwd-key-from-json-key"
-         (ns-kwd-key-from-json-key "agents" "id") => ::specs.agents/id
-         (ns-kwd-key-from-json-key "agents" "name") => ::specs.agents/name
-         (ns-kwd-key-from-json-key "agents" "primary_skillset") => ::specs.agents/primary-skillset
-         (ns-kwd-key-from-json-key "agents" "secondary_skillset") => ::specs.agents/secondary-skillset
-         (ns-kwd-key-from-json-key "job" "id") => ::specs.job/id
-         (ns-kwd-key-from-json-key "job" "type") => ::specs.job/type
-         (ns-kwd-key-from-json-key "job" "urgent") => ::specs.job/urgent
-         (ns-kwd-key-from-json-key "job-request" "agent_id") => ::specs.job-request/agent-id
-         (ns-kwd-key-from-json-key "events" "new_agent") => ::specs.events/new-agent
-         (ns-kwd-key-from-json-key "events" "new_job") => ::specs.events/new-job
-         (ns-kwd-key-from-json-key "events" "job_request") => ::specs.events/job-request)
+         (ns-kwd-key-from-json-key "agents" :id) => ::specs.agents/id
+         (ns-kwd-key-from-json-key "agents" :name) => ::specs.agents/name
+         (ns-kwd-key-from-json-key "agents" :primary_skillset) => ::specs.agents/primary-skillset
+         (ns-kwd-key-from-json-key "agents" :secondary_skillset) => ::specs.agents/secondary-skillset
+         (ns-kwd-key-from-json-key "job" :id) => ::specs.job/id
+         (ns-kwd-key-from-json-key "job" :type) => ::specs.job/type
+         (ns-kwd-key-from-json-key "job" :urgent) => ::specs.job/urgent
+         (ns-kwd-key-from-json-key "job-request" :agent-id) => ::specs.job-request/agent-id
+         (ns-kwd-key-from-json-key "events" :new_agent) => ::specs.events/new-agent
+         (ns-kwd-key-from-json-key "events" :new_job) => ::specs.events/new-job
+         (ns-kwd-key-from-json-key "events" :job_request) => ::specs.events/job-request)
   (facts "clj-event-payload-from-namespace-and-json-event-payload"
          (clj-event-payload-from-namespace-and-json-event-payload "agents" cases/new-agent-json-event-payload-p1) => cases/agent-p1
          (clj-event-payload-from-namespace-and-json-event-payload "job" cases/new-job-json-payload-1t) => cases/job-1t
@@ -79,7 +79,6 @@
          (json-key-from-clj-ns-kwd-key ::specs.job-assigned/job-id) => "job_id"
          (json-key-from-clj-ns-kwd-key ::specs.job-assigned/agent-id) => "agent_id")
   (facts "json-events-str-formatted-from-clj-events"
-         (json-events-str-formatted-from-clj-events cases/jobs-assigned-clj-events) => cases/jobs-assigned-json-events-str)
-  )
+         (json-events-str-formatted-from-clj-events cases/jobs-assigned-clj-events) => cases/jobs-assigned-json-events-str))
 
 (stest/instrument)

--- a/test/queues/json_converter_test.clj
+++ b/test/queues/json_converter_test.clj
@@ -52,6 +52,13 @@
          (clj-event-from-json-event cases/new-agent-json-event-p1) => cases/new-agent-clj-event-p1
          (clj-event-from-json-event cases/new-job-json-event-1t) => cases/new-job-clj-event-1t
          (clj-event-from-json-event cases/job-req-json-event-p1) => cases/job-req-clj-event-p1)
+  (facts "clj-event-from-json-event-str"
+         (fact "if provided with a valid agent json str, returns the corresponding clj-agent"
+               (clj-event-from-json-event-str cases/agent-p1-str) => cases/new-agent-clj-event-p1)
+         (fact "if provided with a a mal formatted json event, throws exception"
+               (clj-event-from-json-event-str cases/mal-formatted-json-event) => (throws Exception))
+         (fact "if provided with a json event that has no corresponding clj event speced, throws exception"
+               (clj-event-from-json-event-str cases/json-event-str-wo-respective-clj-event) => (throws Exception)))
   (facts "clj-events-with-converted-json-event"
          (clj-events-with-converted-json-event [cases/new-job-clj-event-1t] cases/new-agent-json-event-p1) => [cases/new-job-clj-event-1t cases/new-agent-clj-event-p1]
          (clj-events-with-converted-json-event [cases/new-agent-clj-event-p1] cases/new-job-json-event-1t) => [cases/new-agent-clj-event-p1 cases/new-job-clj-event-1t]

--- a/test/queues/service_test.clj
+++ b/test/queues/service_test.clj
@@ -3,15 +3,36 @@
             [io.pedestal.test :refer [response-for]]
             [midje.sweet :refer :all]
             [queues.fixtures :as fix]
-            [queues.service :refer :all]))
+            [queues.service :refer :all]
+            [queues.test-cases :as cases]))
 
 (facts "get '/' endpoint"
-       (fact "endpoint works"
+       (fact "a simple get should return 200"
              (response-for fix/tempserv :get "/") => (contains {:status 200}))
        (fact "if db is empty, return a map with keys jobs-done, jobs-being-done and jobs-queued"
              (response-for fix/tempserv :get "/") => (contains {:body "{\n  \"jobs_done\": [],\n  \"jobs_being_done\": [],\n  \"jobs_queued\": []\n}"})))
 
+(facts "post '/agents' endpoint"
+       (fact "if no agent is provided, returns 400"
+             (response-for fix/tempserv
+                           :post "/agents"
+                           :headers {"Content-Type" "application/json"}
+                           :body "")
+             => (contains {:status 400}))
+       (fact "if a valid agent is provided, returns 201"
+             (response-for fix/tempserv
+                           :post "/agents"
+                           :headers {"Content-Type" "application/json"}
+                           :body "{\n   \"new_agent\": {\n     \"id\": \"8ab86c18-3fae-4804-bfd9-c3d6e8f66260\",\n     \"name\": \"BoJack Horseman\",\n     \"primary_skillset\": [\"bills-questions\"],\n     \"secondary_skillset\": []\n   }\n }\n ")
+             => (contains {:status 201}))
+       (fact "if a valid agent is provided, returns agent"
+             (response-for fix/tempserv
+                           :post "/agents"
+                           :headers {"Content-Type" "application/json"}
+                           :body cases/agent-p1-str)
+             => (contains {:body "{\n  \"new_agent\" : {\n    \"id\" : \"8ab86c18-3fae-4804-bfd9-c3d6e8f66260\",\n    \"name\" : \"BoJack Horseman\",\n    \"primary_skillset\" : [ \"bills-questions\" ],\n    \"secondary_skillset\" : [ ]\n  }\n}"})))
 
+(facts "post '/agents' and then get ")
 
 ;; TODO [TEST] service-test
 

--- a/test/queues/service_test.clj
+++ b/test/queues/service_test.clj
@@ -1,11 +1,13 @@
 (ns queues.service-test
   (:require [clojure.spec.test.alpha :as stest]
+            [io.pedestal.test :refer [response-for]]
             [midje.sweet :refer :all]
+            [queues.fixtures :as fix]
             [queues.service :refer :all]))
 
-;;(facts "agents end-point"
-;;       (fact "receives a put request of an agent returns successful"
-;;             (handled-agent (mock/request :put "/agents")) => (contains {:status 200})))
+(facts "get '/' endpoint"
+       (fact "endpoint works"
+             (response-for fix/tempserv :get "/") => (contains {:status 200})))
 
 ;; TODO [TEST] service-test
 

--- a/test/queues/service_test.clj
+++ b/test/queues/service_test.clj
@@ -7,7 +7,11 @@
 
 (facts "get '/' endpoint"
        (fact "endpoint works"
-             (response-for fix/tempserv :get "/") => (contains {:status 200})))
+             (response-for fix/tempserv :get "/") => (contains {:status 200}))
+       (fact "if db is empty, return a map with keys jobs-done, jobs-being-done and jobs-queued"
+             (response-for fix/tempserv :get "/") => (contains {:body "{\n  \"jobs_done\": [],\n  \"jobs_being_done\": [],\n  \"jobs_queued\": []\n}"})))
+
+
 
 ;; TODO [TEST] service-test
 

--- a/test/queues/test_cases.clj
+++ b/test/queues/test_cases.clj
@@ -235,3 +235,20 @@
                                         "\",\n    \"agent_id\" : \""
                                         agent-p2-s1-id
                                         "\"\n  }\n} ]"))
+
+
+;; ########## Broke on purpose #############
+
+(def skill-1 "bills-questions")
+(def reviewer-p1-id "1")
+(def reviewer-p1-name "Sergio Moro")
+(def json-event-str-wo-respective-clj-event (str "{\n    \"new_reviewer\": {\n      \"id\": \""
+                                                 reviewer-p1-id
+                                                 "\",\n      \"name\": \""
+                                                 reviewer-p1-name
+                                                 "\",\n      \"primary_skillset\": [\""
+                                                 skill-1
+                                                 "\"],\n      \"secondary_skillset\": []\n    }\n  }\n  "))
+(def mal-formatted-json-event (->> agent-p1-str
+                                   (drop-last 10)
+                                   (apply str)))

--- a/test/queues/test_cases.clj
+++ b/test/queues/test_cases.clj
@@ -25,13 +25,13 @@
 
 (def agent-p1-id "8ab86c18-3fae-4804-bfd9-c3d6e8f66260")
 (def agent-p1-name "BoJack Horseman")
-(def agent-p1-str (str "[\n  {\n    \"new_agent\": {\n      \"id\": \""
+(def agent-p1-str (str "{\n    \"new_agent\": {\n      \"id\": \""
                        agent-p1-id
                        "\",\n      \"name\": \""
                        agent-p1-name
                        "\",\n      \"primary_skillset\": [\""
                        skill-1
-                       "\"],\n      \"secondary_skillset\": []\n    }\n  },\n  "))
+                       "\"],\n      \"secondary_skillset\": []\n    }\n  }\n  "))
 (def new-agent-json-event-payload-p1 {"id"                 agent-p1-id
                                       "name"               agent-p1-name
                                       "primary_skillset"   [skill-1]
@@ -46,7 +46,7 @@
 
 (def job-req-json-event-str-p1 (str "{\n    \"job_request\": {\n      \"agent_id\": \""
                                     agent-p1-id
-                                    "\"\n    }\n  },\n  "))
+                                    "\"\n    }\n  }"))
 (def job-req-json-event-payload-p1 {"agent_id" agent-p1-id})
 (def job-req-json-event-type-p1 "job_request")
 (def job-req-json-event-p1 {job-req-json-event-type-p1 job-req-json-event-payload-p1})
@@ -63,37 +63,37 @@
                                          skill-2
                                          "\"],\n      \"secondary_skillset\": [\""
                                          skill-1
-                                         "\"]\n    }\n  },\n  "))
+                                         "\"]\n    }\n  }"))
 (def agent-p2-s1 #::specs.agents{:id                 agent-p2-s1-id,
-                                :name               agent-p2-s1-name,
-                                :primary-skillset   [skill-2],
-                                :secondary-skillset [skill-1]})
+                                 :name               agent-p2-s1-name,
+                                 :primary-skillset   [skill-2],
+                                 :secondary-skillset [skill-1]})
 (def new-agent-clj-event-p2-s1 #::specs.events{:new-agent agent-p2-s1})
 (def job-req-json-str-p2-s1 (str "{\n    \"job_request\": {\n      \"agent_id\": \""
                                  agent-p2-s1-id
-                                 "\"\n    }\n  }\n]\n"))
+                                 "\"\n    }\n  }"))
 (def job-req-clj-event-p2-s1 #::specs.job-request{:agent-id agent-p2-s1-id})
 
 (def agent-p1-s6-id "4")
 (def agent-p1-s6 #::specs.agents{:id                 agent-p1-s6-id,
-                                :name               "Gabriela Lima",
-                                :primary-skillset   [skill-1],
-                                :secondary-skillset [skill-6]})
+                                 :name               "Gabriela Lima",
+                                 :primary-skillset   [skill-1],
+                                 :secondary-skillset [skill-6]})
 (def job-req-p1-s6 #::specs.job-request{:agent-id agent-p1-s6-id})
 
 (def agent-p5=1-id "7")
 (def agent-p5=1 #::specs.agents{:id                 agent-p5=1-id,
-                               :name               "Gabriela Lima",
-                               :primary-skillset   [skill-5=skill-1],
-                               :secondary-skillset []})
+                                :name               "Gabriela Lima",
+                                :primary-skillset   [skill-5=skill-1],
+                                :secondary-skillset []})
 (def job-req-p5=1 #::specs.job-request{:agent-id agent-p5=1-id})
 
 (def agent-p12-id "3")
 
 (def agent-p12 #::specs.agents{:id                 agent-p12-id,
-                              :name               "Gabriela Lima",
-                              :primary-skillset   [skill-1 skill-2],
-                              :secondary-skillset []})
+                               :name               "Gabriela Lima",
+                               :primary-skillset   [skill-1 skill-2],
+                               :secondary-skillset []})
 (def job-req-p12 #::specs.job-request{:agent-id agent-p12-id})
 
 ;; ########## Job #############
@@ -107,7 +107,7 @@
                               job-id-1f
                               "\",\n      \"type\": \""
                               job-type-1
-                              "\",\n      \"urgent\": false\n    }\n  },\n  "))
+                              "\",\n      \"urgent\": false\n    }\n  }"))
 (def job-1f #::specs.job{:id     job-id-1f,
                          :type   job-type-1,
                          :urgent false})
@@ -119,7 +119,7 @@
                               job-id-1t
                               "\",\n      \"type\": \""
                               job-type-1
-                              "\",\n      \"urgent\": true\n    }\n  },\n  "))
+                              "\",\n      \"urgent\": true\n    }\n  }"))
 (def new-job-json-payload-1t {"id"     job-id-1t
                               "type"   job-type-1
                               "urgent" true})
@@ -134,7 +134,7 @@
                               job-id-2f
                               "\",\n      \"type\": \""
                               job-type-2
-                              "\",\n      \"urgent\": false\n    }\n  },\n  "))
+                              "\",\n      \"urgent\": false\n    }\n  }"))
 (def job-2f #::specs.job{:id     job-id-2f,
                          :type   job-type-2,
                          :urgent false})
@@ -148,13 +148,15 @@
 
 ;; ########## Events #############
 
-(def json-events-str (str agent-p1-str
-                          new-job-json-str-2f
-                          new-agent-json-event-str-p2-s1
-                          new-job-json-str-1f
-                          new-job-json-str-1t
-                          job-req-json-event-str-p1
-                          job-req-json-str-p2-s1))
+(def json-events-str (str "[\n"
+                          agent-p1-str ",\n"
+                          new-job-json-str-2f ",\n"
+                          new-agent-json-event-str-p2-s1 ",\n"
+                          new-job-json-str-1f ",\n"
+                          new-job-json-str-1t ",\n"
+                          job-req-json-event-str-p1 ",\n"
+                          job-req-json-str-p2-s1 "\n"
+                          "]"))
 
 
 (def json-events [{"new_agent" {"id"                 agent-p1-id,
@@ -190,12 +192,12 @@
 
 
 (def clj-events [new-agent-clj-event-p1,
-                   new-job-clj-event-2f,
-                   new-agent-clj-event-p2-s1,
-                   new-job-clj-event-1f,
-                   new-job-clj-event-1t,
-                   job-req-clj-event-p1
-                   job-req-clj-event-p2-s1])
+                 new-job-clj-event-2f,
+                 new-agent-clj-event-p2-s1,
+                 new-job-clj-event-1f,
+                 new-job-clj-event-1t,
+                 job-req-clj-event-p1
+                 job-req-clj-event-p2-s1])
 
 (def jobs-waiting-empty [])
 (def jobs-waiting [job-1f-waiting])

--- a/test/queues/test_cases.clj
+++ b/test/queues/test_cases.clj
@@ -32,11 +32,11 @@
                        "\",\n      \"primary_skillset\": [\""
                        skill-1
                        "\"],\n      \"secondary_skillset\": []\n    }\n  }"))
-(def new-agent-json-event-payload-p1 {"id"                 agent-p1-id
-                                      "name"               agent-p1-name
-                                      "primary_skillset"   [skill-1]
-                                      "secondary_skillset" []})
-(def new-agent-json-event-type-p1 "new_agent")
+(def new-agent-json-event-payload-p1 {:id                 agent-p1-id
+                                      :name               agent-p1-name
+                                      :primary_skillset   [skill-1]
+                                      :secondary_skillset []})
+(def new-agent-json-event-type-p1 :new_agent)
 (def new-agent-json-event-p1 {new-agent-json-event-type-p1 new-agent-json-event-payload-p1})
 (def agent-p1 #::specs.agents{:id                 agent-p1-id,
                               :name               agent-p1-name,
@@ -47,8 +47,8 @@
 (def job-req-json-event-str-p1 (str "{\n    \"job_request\": {\n      \"agent_id\": \""
                                     agent-p1-id
                                     "\"\n    }\n  }"))
-(def job-req-json-event-payload-p1 {"agent_id" agent-p1-id})
-(def job-req-json-event-type-p1 "job_request")
+(def job-req-json-event-payload-p1 {:agent_id agent-p1-id})
+(def job-req-json-event-type-p1 :job_request)
 (def job-req-json-event-p1 {job-req-json-event-type-p1 job-req-json-event-payload-p1})
 (def job-req-p1 #::specs.job-request{:agent-id agent-p1-id})
 (def job-req-clj-event-p1 #::specs.events{:job-request job-req-p1})
@@ -120,10 +120,10 @@
                               "\",\n      \"type\": \""
                               job-type-1
                               "\",\n      \"urgent\": true\n    }\n  }"))
-(def new-job-json-payload-1t {"id"     job-id-1t
-                              "type"   job-type-1
-                              "urgent" true})
-(def new-job-json-type-1t "new_job")
+(def new-job-json-payload-1t {:id     job-id-1t
+                              :type   job-type-1
+                              :urgent true})
+(def new-job-json-type-1t :new_job)
 (def new-job-json-event-1t {new-job-json-type-1t new-job-json-payload-1t})
 (def job-1t #::specs.job{:id job-id-1t :type job-type-1 :urgent true})
 (def new-job-clj-event-1t #::specs.events{:new-job job-1t})
@@ -159,25 +159,25 @@
                           "]\n"))
 
 
-(def json-events [{"new_agent" {"id"                 agent-p1-id,
-                                "name"               agent-p1-name,
-                                "primary_skillset"   [skill-1],
-                                "secondary_skillset" []}},
-                  {"new_job" {"id"     job-id-2f,
-                              "type"   job-type-2,
-                              "urgent" false}},
-                  {"new_agent" {"id"                 agent-p2-s1-id,
-                                "name"               agent-p2-s1-name,
-                                "primary_skillset"   [job-type-2],
-                                "secondary_skillset" [job-type-1]}},
-                  {"new_job" {"id"     job-id-1f,
-                              "type"   job-type-1,
-                              "urgent" false}},
-                  {"new_job" {"id"     job-id-1t,
-                              "type"   job-type-1,
-                              "urgent" true}},
-                  {"job_request" {"agent_id" agent-p1-id}},
-                  {"job_request" {"agent_id" agent-p2-s1-id}}])
+(def json-events [{:new_agent {:id                 agent-p1-id,
+                                :name               agent-p1-name,
+                                :primary_skillset   [skill-1],
+                                :secondary_skillset []}},
+                  {:new_job {:id     job-id-2f,
+                              :type   job-type-2,
+                              :urgent false}},
+                  {:new_agent {:id                 agent-p2-s1-id,
+                                :name               agent-p2-s1-name,
+                                :primary_skillset   [job-type-2],
+                                :secondary_skillset [job-type-1]}},
+                  {:new_job {:id     job-id-1f,
+                              :type   job-type-1,
+                              :urgent false}},
+                  {:new_job {:id     job-id-1t,
+                              :type   job-type-1,
+                              :urgent true}},
+                  {:job_request {:agent_id agent-p1-id}},
+                  {:job_request {:agent_id agent-p2-s1-id}}])
 
 ;; ########## Queues and DB #############
 

--- a/test/queues/test_cases.clj
+++ b/test/queues/test_cases.clj
@@ -31,7 +31,7 @@
                        agent-p1-name
                        "\",\n      \"primary_skillset\": [\""
                        skill-1
-                       "\"],\n      \"secondary_skillset\": []\n    }\n  }\n  "))
+                       "\"],\n      \"secondary_skillset\": []\n    }\n  }"))
 (def new-agent-json-event-payload-p1 {"id"                 agent-p1-id
                                       "name"               agent-p1-name
                                       "primary_skillset"   [skill-1]
@@ -148,15 +148,15 @@
 
 ;; ########## Events #############
 
-(def json-events-str (str "[\n"
-                          agent-p1-str ",\n"
-                          new-job-json-str-2f ",\n"
-                          new-agent-json-event-str-p2-s1 ",\n"
-                          new-job-json-str-1f ",\n"
-                          new-job-json-str-1t ",\n"
-                          job-req-json-event-str-p1 ",\n"
+(def json-events-str (str "[\n  "
+                          agent-p1-str ",\n  "
+                          new-job-json-str-2f ",\n  "
+                          new-agent-json-event-str-p2-s1 ",\n  "
+                          new-job-json-str-1f ",\n  "
+                          new-job-json-str-1t ",\n  "
+                          job-req-json-event-str-p1 ",\n  "
                           job-req-json-str-p2-s1 "\n"
-                          "]"))
+                          "]\n"))
 
 
 (def json-events [{"new_agent" {"id"                 agent-p1-id,


### PR DESCRIPTION
Implements basic response functionalities to get /  and post /agents endpoints.
Post endpoints still does not interact with database
Some improvements and refactos in json-converter namespace were necessary to implement the new service functionalities, in particular respeccing json-events to use keyword keys and not string keys as pedestal body-params interceptor parses the body with a str contating json events into json events with keyword keys